### PR TITLE
Macro preprocessor

### DIFF
--- a/bin/buildr.coffee
+++ b/bin/buildr.coffee
@@ -5,12 +5,33 @@ console.log 'Command line buildr may not currently work due to this bug: https:/
 
 # Requires
 cson = require 'cson'
+fs = require "fs"
 buildr = require __dirname+'/../lib/buildr.coffee'
 cwd = process.cwd()
 
-# Parse the config file
-cson.parseFile "#{cwd}/buildr.cson", (err,config) ->
-	throw err if err
-	myBuildr = buildr.createInstance(config)
-	myBuildr.process (err) ->
-		throw err if err
+#Preprocessors
+preprocessors = [
+    (data) ->
+        new_data = data
+        p = /##def\s+(\w+)\s*"(.*?)"/g
+        while m = p.exec data
+            console.log "--> " + m[0]
+            new_data = new_data.replace RegExp(m[1], 'g'), m[2]
+        new_data
+]
+data = ''
+fs.readFile "#{cwd}/buildr.cson", (err,d) ->
+    throw err if err
+    data = d.toString()
+    
+    console.log "Preprocessing configuration file..."
+    for p in preprocessors
+        data = p data
+    console.log "Preprocessed."
+    
+    # Parse the config file
+    cson.parse data, (err,config) ->
+        throw err if err
+        myBuildr = buildr.createInstance(config)
+        myBuildr.process (err) ->
+            throw err if err


### PR DESCRIPTION
Hi,

I have just coded and tested small patch for bin/buildr.coffee,
that allows to define and expand macro constants in buildr.cson
like `##def PROJ_NAME "jascuti"`
_before_ it would be converted to object and passed into core buildr.

Macro syntax is masked in comments, so should not harm anything

_motivation_: e.g. have project name constant populated across whole config file

_Example_:

``` coffeescript
{
    ##def PROJ_NAME "jascuti"

    # Options
    log: true # (log status updates to console?) true or false
    watch: false # (automatically rebuild on file change?) true or false

    # Handlers
    buildHandler: (err) -> # (fired when build completed) function or false
        if err
            console.log err
            throw err
        console.log 'Building completed\n'
    rebuildHandler: (err) -> # (fired when rebuild completed) function or false
        if err
            console.log err
            throw err
        console.log 'ReBuilding completed\n'

    # Paths
    srcPath: 'src' # String
    outPath: 'build' # String or false

    # Checking
    checkScripts: false # Array or true or false
    checkStyles: false # Array or true or false
    jshintOptions: false # Object or false
    csslintOptions: false # Object or false

    # Compression (requires outPath)
    compressScripts: true # Array or true or false
    compressStyles: false # Array or true or false
    compressImages: false # Array or true or false

    # Order
    scriptsOrder: ['common.js', 'namespaces.js']
    stylesOrder: false # Array or false

    # Bundling (requires Order)
    bundleScriptPath: "build/PROJ_NAME.min.js" # String or false
    bundleStylePath: false # String or false
    deleteBundledFiles: true # (requires outPath) true or false

    # Loaders (requires Order) - for debug purpose. in production use bundled minified
    srcLoaderHeader: '''
        # Prepare
        myprojectEl = document.getElementById('buildr_debug_loader')
        myprojectBaseUrl = myprojectEl.src.replace(/\\?.*$/,'').replace(/loader\\.js$/, '').replace(/\\/+$/, '')+'/'

        # Load in with Buildr
        myprojectBuildr = new window.Buildr {
            baseUrl: myprojectBaseUrl
            beforeEl: myprojectEl
            serverCompilation: window.serverCompilation or false
            scripts: scripts
            styles: styles
        }
        myprojectBuildr.load()
        ''' # note, all \ in this are escaped due to it being in a string
    srcLoaderPath: 'build/PROJ_NAME.loader.js' # String or false
    # use something like this in HTML: <script id="buildr_debug_loader" src="PROJ_NAME.loader.js"></script>
}
```

I'm going to use your awesome Buildr with this patch in my projects :),
so it would be nice have this in the upstream.

Thanks!
