### PR TITLE
Enable configured build handler with command-line tool

### DIFF
--- a/bin/buildr.coffee
+++ b/bin/buildr.coffee
@@ -12,5 +12,4 @@ cwd = process.cwd()
 cson.parseFile "#{cwd}/buildr.cson", (err,config) ->
 	throw err if err
 	myBuildr = buildr.createInstance(config)
-	myBuildr.process (err) ->
-		throw err if err
+	myBuildr.process()

--- a/lib/buildr.coffee
+++ b/lib/buildr.coffee
@@ -100,18 +100,20 @@ class Buildr
 		@config = tmp
 
 		# Handlers
-		@config.buildHandler or= (err) =>
+		@config.buildHandler or= (err) ->
 			if err
 				@log 'error', err
 				throw err
 			@log 'info', 'Building completed'
-			@config.successHandler.call(@)  if @config.successHandler
-		@config.rebuildHandler or= (err) =>
+			@config.successHandler.call(@) if @config.successHandler
+		@afterBuild = (err) => @config.buildHandler.call(@,err)
+		@config.rebuildHandler or= (err) ->
 			if err
 				@log 'error', err
 				throw err
 			@log 'info', 'ReBuilding completed'
 			@config.successHandler.call(@) if @config.successHandler
+		@afterRebuild = (err) => @config.rebuildHandler.call(@,err)
 
 		# Logger
 		if @config.log is true then @config.log = 6
@@ -150,7 +152,7 @@ class Buildr
 		# Prepare
 		buildr = @
 		log = @log
-		next or= @config.rebuildHandler or @config.buildHandler
+		next or= @afterRebuild
 
 		# Log
 		log 'debug', 'Setting up watching...'
@@ -186,7 +188,7 @@ class Buildr
 		
 		# Prepare
 		log = @log
-		next or= @config.buildHandler
+		next or= @afterBuild
 
 		# Log
 		log 'info', 'Processing started'


### PR DESCRIPTION
As of v0.8.2, the command-line tool supplies a minimal build handler argument to the "process" method. This handler has the effect of overriding any build handler which may be configured. The changes in this pull request have the following effects:
- omit the command-line tool build handler, so that the configured or default build handler is used
- bind any configured build handler to the Buildr instance (previously, only the default handlers were so bound)
